### PR TITLE
Fixed pairing for TnG 550

### DIFF
--- a/src/android/BLECentralPlugin.java
+++ b/src/android/BLECentralPlugin.java
@@ -849,7 +849,7 @@ public class BLECentralPlugin extends CordovaPlugin {
         pairedDevice = bluetoothAdapter.getRemoteDevice(macAddress);
 
         if (COMPILE_SDK_VERSION >= 29 && Build.VERSION.SDK_INT >= 29 && (pairedDevice.getName().contains("UA-651") || pairedDevice.getName().contains("UC-352")
-                || pairedDevice.getName().contains("IR20") || pairedDevice.getName().contains("TNG SCALE") || pairedDevice.getName().contains("TAIDOC TD8255")
+                || pairedDevice.getName().contains("IR20") || pairedDevice.getName().contains("TAIDOC TD8255")
                 || pairedDevice.getName().contains("TD1107") || pairedDevice.getName().contains("Nonin3230")
         )) {
             LOG.d(TAG, "Bond State for Version > 29" + peripheral.getDevice().getBondState());
@@ -859,6 +859,7 @@ public class BLECentralPlugin extends CordovaPlugin {
                 BluetoothDevice device = bluetoothAdapter.getRemoteDevice(macAddress);
                 setPairingCallback((btDevice, bondedState) -> {
                     LOG.d(TAG, "onPairingComplete Callback:" + btDevice);
+                    LOG.d(TAG, "onPairingComplete Callback bond state:" + bondedState);
                     if(bondedState == BluetoothDevice.BOND_BONDED) {
                         LOG.d(TAG, "onPairingComplete Initiate GattConnect:" + btDevice);
                         Peripheral peripheralDevice = new Peripheral(btDevice);
@@ -1181,6 +1182,7 @@ public class BLECentralPlugin extends CordovaPlugin {
         @Override
         public void onScanFailed(int errorCode) {
             super.onScanFailed(errorCode);
+            LOG.d(TAG, "Scan FAILED "  + errorCode);
         }
     };
 

--- a/src/android/Peripheral.java
+++ b/src/android/Peripheral.java
@@ -412,6 +412,7 @@ public class Peripheral extends BluetoothGattCallback {
      */
     public enum AUTO_CONNECT_OFF_DEVICES {
         WELCH_SC100("SC100"),
+        TNG_SCALE("TNG SCALE"),
         WELCH_BP100("BP100");
 
         private String text;
@@ -429,7 +430,7 @@ public class Peripheral extends BluetoothGattCallback {
                 String text = device.getName();
                 if (text != null ) {
                     for (Peripheral.AUTO_CONNECT_OFF_DEVICES b : Peripheral.AUTO_CONNECT_OFF_DEVICES.values()) {
-                        if (text.indexOf(b.text) > 0) {
+                        if(text.equals(b.text)) {
                             return true;
                         }
                     }


### PR DESCRIPTION
**For FORA TnG 550 Scale :**
**Issue** -> When we put device in pairing mode, it never gets paired. BT icon keeps on blinking. This happens as for 29 and above device we are explicitly calling 'createBond()' and once that happens the device bond state is changing from 10 (not bonded) -> 11 (bonding) -> 12 (bonded) and then automatically changes to 10 again making is unpaired.
For FORA 550 scale, I checked this behaviour on Samsung S5E (android 10) and Google Pixel 13  and same is happening over there also.

**Solution** ->
It seems, this device does not require createBond explicitly. In BLE plugin, we can turn it off for this device in general for API 29 and above as Samsung S5E also shows the same behavior. We can let it make call to connect as it was doing earlier.
Also, while making connection this device is throwing gatt 133 a number of times, thus to fix that we can try re-connecting a few times before declaring a disconnection (like we are doing for welch)
