### PR TITLE
Logging Framework Changes-Migrate to Timber

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -94,6 +94,7 @@
             target-dir="src/com/megster/cordova/ble/central"/>
         <source-file src="src/android/L2CAPContext.java"
             target-dir="src/com/megster/cordova/ble/central"/>
+        <framework src="com.jakewharton.timber:timber:5.0.1" />
     </platform>
 
     <platform name="browser">

--- a/src/android/BLECentralPlugin.java
+++ b/src/android/BLECentralPlugin.java
@@ -39,7 +39,6 @@ import android.os.Looper;
 import android.os.Build;
 
 import android.provider.Settings;
-import android.util.Log;
 
 import org.apache.cordova.CallbackContext;
 import org.apache.cordova.CordovaArgs;
@@ -51,6 +50,7 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 import org.json.JSONException;
 import java.lang.reflect.Method;
+import timber.log.Timber;
 
 import java.util.*;
 
@@ -206,7 +206,7 @@ public class BLECentralPlugin extends CordovaPlugin {
 
     @Override
     public boolean execute(String action, CordovaArgs args, CallbackContext callbackContext) throws JSONException {
-        LOG.d(TAG, "action = %s", action);
+        Timber.i("action = %s", action);
 
         if (bluetoothAdapter == null) {
             Activity activity = cordova.getActivity();
@@ -622,7 +622,7 @@ public class BLECentralPlugin extends CordovaPlugin {
 
     private void onBluetoothStateChange(Intent intent) {
         final String action = intent.getAction();
-        LOG.d(TAG, "onBluetoothStateChange" + action);
+        Timber.i("onBluetoothStateChange" + action);
 
         if (action.equals(BluetoothAdapter.ACTION_STATE_CHANGED)) {
             final int state = intent.getIntExtra(BluetoothAdapter.EXTRA_STATE, BluetoothAdapter.ERROR);
@@ -681,7 +681,7 @@ public class BLECentralPlugin extends CordovaPlugin {
             IntentFilter intentFilter = new IntentFilter(BluetoothAdapter.ACTION_STATE_CHANGED);
             webView.getContext().registerReceiver(this.stateReceiver, intentFilter);
         } catch (Exception e) {
-            LOG.e(TAG, "Error registering state receiver: " + e.getMessage(), e);
+            Timber.e("Error registering state receiver: %s", e.getMessage());
         }
     }
 
@@ -699,7 +699,7 @@ public class BLECentralPlugin extends CordovaPlugin {
             IntentFilter intentFilter = new IntentFilter(BluetoothDevice.ACTION_BOND_STATE_CHANGED);
             webView.getContext().registerReceiver(this.bondStateReceiver, intentFilter);
         } catch (Exception e) {
-            LOG.e(TAG, "Error registering bond state receiver: " + e.getMessage(), e);
+            Timber.e("Error registering bond state receiver: %s", e.getMessage());
         }
     }
 
@@ -708,7 +708,7 @@ public class BLECentralPlugin extends CordovaPlugin {
             try {
                 webView.getContext().unregisterReceiver(this.bondStateReceiver);
             } catch (Exception e) {
-                LOG.e(TAG, "Error unregistering bond state receiver: " + e.getMessage(), e);
+                Timber.e("Error unregistering bond state receiver: %s", e.getMessage());
             }
         }
         this.bondStateCallback = null;
@@ -720,7 +720,7 @@ public class BLECentralPlugin extends CordovaPlugin {
             try {
                 webView.getContext().unregisterReceiver(this.stateReceiver);
             } catch (Exception e) {
-                LOG.e(TAG, "Error unregistering state receiver: " + e.getMessage(), e);
+                Timber.e("Error unregistering state receiver: %s", e.getMessage());
             }
         }
         this.stateCallback = null;
@@ -758,7 +758,7 @@ public class BLECentralPlugin extends CordovaPlugin {
             intentFilter.addAction(Intent.ACTION_PROVIDER_CHANGED);
             webView.getContext().registerReceiver(this.locationStateReceiver, intentFilter);
         } catch (Exception e) {
-            LOG.e(TAG, "Error registering location state receiver: " + e.getMessage(), e);
+            Timber.e("Error registering location state receiver: %s", e.getMessage());
         }
     }
 
@@ -767,7 +767,7 @@ public class BLECentralPlugin extends CordovaPlugin {
             try {
                 webView.getContext().unregisterReceiver(this.locationStateReceiver);
             } catch (Exception e) {
-                LOG.e(TAG, "Error unregistering location state receiver: " + e.getMessage(), e);
+                Timber.e("Error unregistering location state receiver: %s", e.getMessage());
             }
         }
         this.locationStateCallback = null;
@@ -831,8 +831,8 @@ public class BLECentralPlugin extends CordovaPlugin {
         if (peripheral == null) {
             if (BluetoothAdapter.checkBluetoothAddress(macAddress)) {
                 BluetoothDevice device = bluetoothAdapter.getRemoteDevice(macAddress);
-                LOG.d(TAG, "Device Mac Address" + device);
-                LOG.d(TAG, "Bond State"+ bondedState);
+                Timber.i("Device Mac Address %s", device);
+                Timber.i("Bond State %s", bondedState);
 
                 peripheral = new Peripheral(device);
                 peripherals.put(device.getAddress(), peripheral);
@@ -852,16 +852,16 @@ public class BLECentralPlugin extends CordovaPlugin {
                 || pairedDevice.getName().contains("IR20") || pairedDevice.getName().contains("TAIDOC TD8255")
                 || pairedDevice.getName().contains("TD1107") || pairedDevice.getName().contains("Nonin3230")
         )) {
-            LOG.d(TAG, "Bond State for Version > 29" + peripheral.getDevice().getBondState());
+            Timber.i("Bond State for Version > 29" + peripheral.getDevice().getBondState());
             if (peripheral.getDevice().getBondState() == BluetoothDevice.BOND_BONDED) {
                 peripheral.connect(callbackContext, cordova.getActivity(), false);// TODO setting this to false to stop auto connecting
             } else {
                 BluetoothDevice device = bluetoothAdapter.getRemoteDevice(macAddress);
                 setPairingCallback((btDevice, bondedState) -> {
-                    LOG.d(TAG, "onPairingComplete Callback:" + btDevice);
-                    LOG.d(TAG, "onPairingComplete Callback bond state:" + bondedState);
+                    Timber.i("onPairingComplete Callback:" + btDevice);
+                    Timber.i("onPairingComplete Callback bond state:" + bondedState);
                     if(bondedState == BluetoothDevice.BOND_BONDED) {
-                        LOG.d(TAG, "onPairingComplete Initiate GattConnect:" + btDevice);
+                        Timber.i("onPairingComplete Initiate GattConnect:" + btDevice);
                         Peripheral peripheralDevice = new Peripheral(btDevice);
                         peripheralDevice.connect(callbackContext, cordova.getActivity(), false); // TODO setting this to false to stop auto connecting
                     }
@@ -882,9 +882,9 @@ public class BLECentralPlugin extends CordovaPlugin {
             try {
                 Method method = device.getClass().getMethod("removeBond", (Class[]) null);
                 method.invoke(device, (Object[]) null);
-                LOG.i(TAG, "Successfully removed bond");
+                Timber.i("Successfully removed bond");
             } catch (Exception e) {
-                LOG.e(TAG, "ERROR: could not remove bond");
+                Timber.e("ERROR: could not remove bond");
                 e.printStackTrace();
             }
             callbackContext.success();
@@ -893,9 +893,9 @@ public class BLECentralPlugin extends CordovaPlugin {
             try {
                 Method method = device.getClass().getMethod("removeBond", (Class[]) null);
                 method.invoke(device, (Object[]) null);
-                LOG.i(TAG, "Successfully removed bond from device");
+                Timber.i("Successfully removed bond from device");
             } catch (Exception e) {
-                LOG.e(TAG, "ERROR: could not remove bond from device");
+                Timber.e("ERROR: could not remove bond from device");
                 e.printStackTrace();
             }
             callbackContext.success();
@@ -1193,7 +1193,7 @@ public class BLECentralPlugin extends CordovaPlugin {
         @Override
         public void onScanFailed(int errorCode) {
             super.onScanFailed(errorCode);
-            LOG.d(TAG, "Scan FAILED "  + errorCode);
+            Timber.i("Scan FAILED "  + errorCode);
         }
     };
 
@@ -1281,7 +1281,7 @@ public class BLECentralPlugin extends CordovaPlugin {
             Peripheral device = entry.getValue();
             boolean connecting = device.isConnecting();
             if (connecting){
-                LOG.d(TAG, "Not removing connecting device: " + device.getDevice().getAddress());
+                Timber.i("Not removing connecting device: " + device.getDevice().getAddress());
             }
             if(!entry.getValue().isConnected() && !connecting) {
                 iterator.remove();
@@ -1313,7 +1313,7 @@ public class BLECentralPlugin extends CordovaPlugin {
     private void stopScan() {
         stopScanHandler.removeCallbacks(this::stopScan);
         if (bluetoothAdapter.getState() == BluetoothAdapter.STATE_ON) {
-            LOG.d(TAG, "Stopping Scan");
+            Timber.i("Stopping Scan");
             try {
                 final BluetoothLeScanner bluetoothLeScanner = bluetoothAdapter.getBluetoothLeScanner();
                 if (bluetoothLeScanner != null)
@@ -1329,7 +1329,7 @@ public class BLECentralPlugin extends CordovaPlugin {
                 pluginResult.setKeepCallback(true);
                 discoverCallback.sendPluginResult(pluginResult);
             } catch (Exception e) {
-                LOG.e(TAG, "Exception stopping scan", e);
+                Timber.e("Exception stopping scan %s", e.getMessage());
             }
         }
     }
@@ -1339,7 +1339,7 @@ public class BLECentralPlugin extends CordovaPlugin {
         try {
             locationMode = Settings.Secure.getInt(cordova.getActivity().getContentResolver(), Settings.Secure.LOCATION_MODE);
         } catch (Settings.SettingNotFoundException e) {
-            LOG.e(TAG, "Location Mode Setting Not Found", e);
+            Timber.e("Location Mode Setting Not Found %s", e.getMessage());
         }
         return (locationMode > 0);
     }
@@ -1373,12 +1373,12 @@ public class BLECentralPlugin extends CordovaPlugin {
         if (requestCode == REQUEST_ENABLE_BLUETOOTH) {
 
             if (resultCode == Activity.RESULT_OK) {
-                LOG.d(TAG, "User enabled Bluetooth");
+                Timber.i("User enabled Bluetooth");
                 if (enableBluetoothCallback != null) {
                     enableBluetoothCallback.success();
                 }
             } else {
-                LOG.d(TAG, "User did *NOT* enable Bluetooth");
+                Timber.i("User did *NOT* enable Bluetooth");
                 if (enableBluetoothCallback != null) {
                     enableBluetoothCallback.error("User did not enable Bluetooth");
                 }
@@ -1413,19 +1413,19 @@ public class BLECentralPlugin extends CordovaPlugin {
         // Users MUST accept ACCESS_COARSE_LOCATION
         for (int i = 0; i < permissions.length; i++) {
             if (permissions[i].equals(Manifest.permission.ACCESS_FINE_LOCATION) && grantResults[i] == PackageManager.PERMISSION_DENIED) {
-                LOG.d(TAG, "User *rejected* Fine Location Access");
+                Timber.i("User *rejected* Fine Location Access");
                 callback.error("Location permission not granted.");
                 return;
             } else if (permissions[i].equals(Manifest.permission.ACCESS_COARSE_LOCATION) && grantResults[i] == PackageManager.PERMISSION_DENIED) {
-                LOG.d(TAG, "User *rejected* Coarse Location Access");
+                Timber.i("User *rejected* Coarse Location Access");
                 callback.error("Location permission not granted.");
                 return;
             } else if (permissions[i].equals(BLUETOOTH_SCAN) && grantResults[i] == PackageManager.PERMISSION_DENIED) {
-                LOG.d(TAG, "User *rejected* Bluetooth_Scan Access");
+                Timber.i("User *rejected* Bluetooth_Scan Access");
                 callback.error("Bluetooth scan permission not granted.");
                 return;
             } else if (permissions[i].equals(BLUETOOTH_CONNECT) && grantResults[i] == PackageManager.PERMISSION_DENIED) {
-                LOG.d(TAG, "User *rejected* Bluetooth_Connect Access");
+                Timber.i("User *rejected* Bluetooth_Connect Access");
                 callback.error("Bluetooth Connect permission not granted.");
                 return;
             }
@@ -1433,12 +1433,12 @@ public class BLECentralPlugin extends CordovaPlugin {
 
         switch(requestCode) {
             case REQUEST_ENABLE_BLUETOOTH:
-                LOG.d(TAG, "User granted Bluetooth Connect access for enable bluetooth");
+                Timber.i("User granted Bluetooth Connect access for enable bluetooth");
                 enableBluetooth(callback);
                 break;
 
             case REQUEST_BLUETOOTH_SCAN:
-                LOG.d(TAG, "User granted Bluetooth Scan Access");
+                Timber.i("User granted Bluetooth Scan Access");
                 findLowEnergyDevices(callback, serviceUUIDs, scanSeconds, scanSettings);
                 this.serviceUUIDs = null;
                 this.scanSeconds = -1;
@@ -1446,24 +1446,24 @@ public class BLECentralPlugin extends CordovaPlugin {
                 break;
 
             case REQUEST_BLUETOOTH_CONNECT:
-                LOG.d(TAG, "User granted Bluetooth Connect Access");
+                Timber.i("User granted Bluetooth Connect Access");
                 connect(callback, deviceMacAddress);
                 this.deviceMacAddress = null;
                 break;
 
             case REQUEST_BLUETOOTH_CONNECT_AUTO:
-                LOG.d(TAG, "User granted Bluetooth Auto Connect Access");
+                Timber.i("User granted Bluetooth Auto Connect Access");
                 autoConnect(callback, deviceMacAddress);
                 this.deviceMacAddress = null;
                 break;
 
             case REQUEST_GET_BONDED_DEVICES:
-                LOG.d(TAG, "User granted permissions for bonded devices");
+                Timber.i("User granted permissions for bonded devices");
                 getBondedDevices(callback);
                 break;
 
             case REQUEST_LIST_KNOWN_DEVICES:
-                LOG.d(TAG, "User granted permissions for list known devices");
+                Timber.i("User granted permissions for list known devices");
                 listKnownDevices(callback);
                 break;
         }

--- a/src/android/L2CAPContext.java
+++ b/src/android/L2CAPContext.java
@@ -15,6 +15,7 @@ import java.io.OutputStream;
 import java.util.Arrays;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import timber.log.Timber;
 
 class L2CAPContext {
     private static final String TAG = "L2CAPContext";
@@ -52,7 +53,7 @@ class L2CAPContext {
                 callbackContext.error("L2CAP not supported by platform");
             }
         } catch (Exception e) {
-            LOG.e(TAG, "connect L2Cap failed", e);
+            Timber.e("connect L2Cap failed %s", e.getMessage());
             callbackContext.error("Failed to open L2Cap connection");
         }
     }
@@ -72,7 +73,7 @@ class L2CAPContext {
                 socket = null;
             }
         } catch (Exception e) {
-            LOG.e(TAG, "disconnect L2Cap failed", e);
+            Timber.e("disconnect L2Cap failed %s", e.getMessage());
         }
         CallbackContext callback;
         synchronized (updateLock) {
@@ -101,7 +102,7 @@ class L2CAPContext {
             outputStream.write(data);
             callbackContext.success();
         } catch (IOException e) {
-            LOG.e(TAG, "L2Cap write failed", e);
+            Timber.e("L2Cap write failed %s", e.getMessage());
             disconnectL2Cap("L2Cap write pipe broken");
             callbackContext.error("L2CAP write failed");
         }
@@ -128,7 +129,7 @@ class L2CAPContext {
             disconnectL2Cap("L2Cap channel disconnected");
 
         } catch (Exception e) {
-            LOG.e(TAG, "reading L2Cap data failed", e);
+            Timber.e("reading L2Cap data failed %s", e.getMessage());
             disconnectL2Cap("L2Cap read pipe broken");
         }
     }

--- a/src/android/Peripheral.java
+++ b/src/android/Peripheral.java
@@ -20,7 +20,7 @@ import android.bluetooth.*;
 import android.os.Build;
 import android.os.Handler;
 import android.util.Base64;
-import android.util.Log;
+import timber.log.Timber;
 
 import org.apache.cordova.CallbackContext;
 import org.apache.cordova.LOG;
@@ -71,7 +71,7 @@ public class Peripheral extends BluetoothGattCallback {
 
     public Peripheral(BluetoothDevice device) {
 
-        LOG.d(TAG, "Creating un-scanned peripheral entry for address: %s", device.getAddress());
+        Timber.i("Creating un-scanned peripheral entry for address: %s", device.getAddress());
 
         this.device = device;
         this.advertisingRSSI = FAKE_PERIPHERAL_RSSI;
@@ -179,7 +179,7 @@ public class Peripheral extends BluetoothGattCallback {
     @Override
     public void onMtuChanged(BluetoothGatt gatt, int mtu, int status) {
         super.onMtuChanged(gatt, mtu, status);
-        LOG.d(TAG, "mtu=%d, status=%d", mtu, status);
+        Timber.i("mtu=%d, status=%d", mtu, status);
 
         if (status == BluetoothGatt.GATT_SUCCESS) {
             requestMtuCallback.success(mtu);
@@ -190,7 +190,7 @@ public class Peripheral extends BluetoothGattCallback {
     }
 
     public void requestMtu(CallbackContext callback, int mtuValue) {
-        LOG.d(TAG, "requestMtu mtu=%d", mtuValue);
+        Timber.i("requestMtu mtu=%d", mtuValue);
         if (gatt == null) {
             callback.error("No GATT");
             return;
@@ -209,7 +209,7 @@ public class Peripheral extends BluetoothGattCallback {
 
     public void requestConnectionPriority(int priority) {
         if (gatt != null) {
-            LOG.d(TAG, "requestConnectionPriority priority=" + priority);
+            Timber.i("requestConnectionPriority priority=%s", priority);
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
                 gatt.requestConnectionPriority(priority);
             }
@@ -225,7 +225,7 @@ public class Peripheral extends BluetoothGattCallback {
      *
      */
     public void refreshDeviceCache(CallbackContext callback, final long timeoutMillis) {
-        LOG.d(TAG, "refreshDeviceCache");
+        Timber.i("refreshDeviceCache");
 
         boolean success = false;
         if (gatt != null) {
@@ -236,7 +236,7 @@ public class Peripheral extends BluetoothGattCallback {
                     if (success) {
                         this.refreshCallback = callback;
                         Handler handler = new Handler();
-                        LOG.d(TAG, "Waiting " + timeoutMillis + " milliseconds before discovering services");
+                        Timber.i("Waiting " + timeoutMillis + " milliseconds before discovering services");
                         handler.postDelayed(new Runnable() {
                             @Override
                             public void run() {
@@ -244,7 +244,7 @@ public class Peripheral extends BluetoothGattCallback {
                                     try {
                                         gatt.discoverServices();
                                     } catch(Exception e) {
-                                        LOG.e(TAG, "refreshDeviceCache Failed after delay", e);
+                                        Timber.e("refreshDeviceCache Failed after delay %s", e.getMessage());
                                     }
                                 }
                             }
@@ -254,7 +254,7 @@ public class Peripheral extends BluetoothGattCallback {
                     LOG.w(TAG, "Refresh method not found on gatt");
                 }
             } catch(Exception e) {
-                LOG.e(TAG, "refreshDeviceCache Failed", e);
+                Timber.e("refreshDeviceCache Failed %s", e.getMessage());
             }
         }
 
@@ -395,7 +395,7 @@ public class Peripheral extends BluetoothGattCallback {
                 connectCallback.sendPluginResult(result);
             }
         } else {
-            LOG.e(TAG, "Service discovery failed. status = %d", status);
+            Timber.e("Service discovery failed. status = %d", status);
             if (refreshCallback != null) {
                 refreshCallback.error(this.asJSONObject("Service discovery failed"));
                 refreshCallback = null;
@@ -446,38 +446,38 @@ public class Peripheral extends BluetoothGattCallback {
         this.gatt = gatt;
 
         if (newState == BluetoothGatt.STATE_CONNECTED) {
-            LOG.d(TAG, "onConnectionStateChange CONNECTED");
+            Timber.i("onConnectionStateChange CONNECTED");
             connected = true;
             connecting = false;
             gatt.discoverServices();
 
         } else {  // Disconnected
-            Log.d(TAG, "On connection state change ---> " + status + " disconnect count " + disconnectCount);
+            Timber.i("On connection state change ---> " + status + " disconnect count " + disconnectCount);
 
             if (AUTO_CONNECT_OFF_DEVICES.shouldRetryForGatt133Status(this.device)) {
-                Log.d(TAG, "Will retry to connect");
+                Timber.i("Will retry to connect");
                 if (newState == BluetoothProfile.STATE_DISCONNECTED) {
                     if (status != 133 || disconnectCount >= 2) { /*If more then 2 count gatt close process*/
                         disconnectCount = 0;
-                        LOG.d(TAG, "onConnectionStateChange DISCONNECTED");
+                        Timber.i("onConnectionStateChange DISCONNECTED");
                         connected = false;
                         peripheralDisconnected("Peripheral Disconnected");
                     } else { /*reconnection goes here*/
                         disconnectCount++;
                         if (connected) {
-                            Log.d(TAG, "While retrying after gatt 133, calling to disconnect");
+                            Timber.i("While retrying after gatt 133, calling to disconnect");
                             disconnect();
                         } else {
-                            Log.d(TAG, "While retrying after gatt 133, calling to connect");
+                            Timber.i("While retrying after gatt 133, calling to connect");
                             if (connectCallback!=null && currentActivity!=null) {
-                                Log.d(TAG, "Gatt 133 error -> Got callback and trying again to connect -->");
+                                Timber.i("Gatt 133 error -> Got callback and trying again to connect -->");
                                 connect(connectCallback, currentActivity, false);
                             }
                         }
                     }
                 }
             } else {
-                LOG.d(TAG, "onConnectionStateChange DISCONNECTED");
+                Timber.i("onConnectionStateChange DISCONNECTED");
                 connected = false;
                 peripheralDisconnected("Peripheral Disconnected");
             }
@@ -487,7 +487,7 @@ public class Peripheral extends BluetoothGattCallback {
     @Override
     public void onCharacteristicChanged(BluetoothGatt gatt, BluetoothGattCharacteristic characteristic) {
         super.onCharacteristicChanged(gatt, characteristic);
-        LOG.d(TAG, "onCharacteristicChanged %s", characteristic);
+        Timber.i("onCharacteristicChanged %s", characteristic);
 
         SequentialCallbackContext callback = notificationCallbacks.get(generateHashKey(characteristic));
 
@@ -499,7 +499,7 @@ public class Peripheral extends BluetoothGattCallback {
     @Override
     public void onCharacteristicRead(BluetoothGatt gatt, BluetoothGattCharacteristic characteristic, int status) {
         super.onCharacteristicRead(gatt, characteristic, status);
-        LOG.d(TAG, "onCharacteristicRead %s", characteristic);
+        Timber.i("onCharacteristicRead %s", characteristic);
 
         synchronized(this) {
             if (readCallback != null) {
@@ -519,7 +519,7 @@ public class Peripheral extends BluetoothGattCallback {
     @Override
     public void onCharacteristicWrite(BluetoothGatt gatt, BluetoothGattCharacteristic characteristic, int status) {
         super.onCharacteristicWrite(gatt, characteristic, status);
-        LOG.d(TAG, "onCharacteristicWrite %s", characteristic);
+        Timber.i("onCharacteristicWrite %s", characteristic);
 
         synchronized(this) {
             if (writeCallback != null) {
@@ -539,7 +539,7 @@ public class Peripheral extends BluetoothGattCallback {
     @Override
     public void onDescriptorWrite(BluetoothGatt gatt, BluetoothGattDescriptor descriptor, int status) {
         super.onDescriptorWrite(gatt, descriptor, status);
-        LOG.d(TAG, "onDescriptorWrite %s", descriptor);
+        Timber.i("onDescriptorWrite %s", descriptor);
         if (descriptor.getUuid().equals(CLIENT_CHARACTERISTIC_CONFIGURATION_UUID)) {
             BluetoothGattCharacteristic characteristic = descriptor.getCharacteristic();
             String key = generateHashKey(characteristic);
@@ -931,7 +931,7 @@ public class Peripheral extends BluetoothGattCallback {
     }
 
     public void writeL2CapChannel(CallbackContext callbackContext, int psm, byte[] data) {
-        LOG.d(TAG,"L2CAP Write %s", psm);
+        Timber.i(TAG,"L2CAP Write %s", psm);
         getOrAddL2CAPContext(psm).writeL2CapChannel(callbackContext, data);
     }
 
@@ -952,7 +952,7 @@ public class Peripheral extends BluetoothGattCallback {
 
     // add a new command to the queue
     private void queueCommand(BLECommand command) {
-        LOG.d(TAG,"Queuing Command %s", command);
+        Timber.i(TAG,"Queuing Command %s", command);
         commandQueue.add(command);
 
         PluginResult result = new PluginResult(PluginResult.Status.NO_RESULT);
@@ -964,7 +964,7 @@ public class Peripheral extends BluetoothGattCallback {
 
     // command finished, queue the next command
     private void commandCompleted() {
-        LOG.d(TAG,"Processing Complete");
+        Timber.i(TAG,"Processing Complete");
         bleProcessing.set(false);
         processCommands();
     }
@@ -973,27 +973,27 @@ public class Peripheral extends BluetoothGattCallback {
     private void processCommands() {
         final boolean canProcess = bleProcessing.compareAndSet(false, true);
         if (!canProcess) { return; }
-        LOG.d(TAG,"Processing Commands");
+        Timber.i(TAG,"Processing Commands");
 
         BLECommand command = commandQueue.poll();
         if (command != null) {
             if (command.getType() == BLECommand.READ) {
-                LOG.d(TAG,"Read %s", command.getCharacteristicUUID());
+                Timber.i(TAG,"Read %s", command.getCharacteristicUUID());
                 readCharacteristic(command.getCallbackContext(), command.getServiceUUID(), command.getCharacteristicUUID());
             } else if (command.getType() == BluetoothGattCharacteristic.WRITE_TYPE_DEFAULT) {
-                LOG.d(TAG,"Write %s", command.getCharacteristicUUID());
+                Timber.i(TAG,"Write %s", command.getCharacteristicUUID());
                 writeCharacteristic(command.getCallbackContext(), command.getServiceUUID(), command.getCharacteristicUUID(), command.getData(), command.getType());
             } else if (command.getType() == BluetoothGattCharacteristic.WRITE_TYPE_NO_RESPONSE) {
-                LOG.d(TAG,"Write No Response %s", command.getCharacteristicUUID());
+                Timber.i(TAG,"Write No Response %s", command.getCharacteristicUUID());
                 writeCharacteristic(command.getCallbackContext(), command.getServiceUUID(), command.getCharacteristicUUID(), command.getData(), command.getType());
             } else if (command.getType() == BLECommand.REGISTER_NOTIFY) {
-                LOG.d(TAG,"Register Notify %s", command.getCharacteristicUUID());
+                Timber.i(TAG,"Register Notify %s", command.getCharacteristicUUID());
                 registerNotifyCallback(command.getCallbackContext(), command.getServiceUUID(), command.getCharacteristicUUID());
             } else if (command.getType() == BLECommand.REMOVE_NOTIFY) {
-                LOG.d(TAG,"Remove Notify %s", command.getCharacteristicUUID());
+                Timber.i(TAG,"Remove Notify %s", command.getCharacteristicUUID());
                 removeNotifyCallback(command.getCallbackContext(), command.getServiceUUID(), command.getCharacteristicUUID());
             } else if (command.getType() == BLECommand.READ_RSSI) {
-                LOG.d(TAG,"Read RSSI");
+                Timber.i(TAG,"Read RSSI");
                 readRSSI(command.getCallbackContext());
             } else {
                 // this shouldn't happen
@@ -1002,7 +1002,7 @@ public class Peripheral extends BluetoothGattCallback {
             }
         } else {
             bleProcessing.set(false);
-            LOG.d(TAG, "Command Queue is empty.");
+            Timber.i("Command Queue is empty.");
         }
 
     }


### PR DESCRIPTION
This does not currently resolve a ticket in Jira, but is a necessary update to migrate over to Timber from the native android logger. The logging framework "Plants" a Timber tree so-to-speak that intercepts all Timber logs and plants them into a local file. This means we don't have to do anything except call out to Timber ourselves.

For the purposes of maximum logging, I've migrated all of our `Log.d` entries over to `Timber.i` in order to get them to show up in production. I couldn't find any security vulnerabilities or UUIDs being missed there, so this should be ok, but if in my haste I missed something it should be easy to correct.

No changes to Unit Tests or Integration tests should be necessary.