### PR TITLE
DEV-14548 Changes for allowing retry for the supported BLE devices, log enhancements

### DIFF
--- a/src/android/Peripheral.java
+++ b/src/android/Peripheral.java
@@ -444,7 +444,6 @@ public class Peripheral extends BluetoothGattCallback {
 //                        if(text.equals(b.text)) {
 //                            return true;
                         if(text.equals(b.text) || text.contains(b.text)) {
-                            Timber.d("Can retry for the connecting the device if status code is 133 -> " + text);
                             return true;
                         }
                     }

--- a/src/android/Peripheral.java
+++ b/src/android/Peripheral.java
@@ -424,6 +424,7 @@ public class Peripheral extends BluetoothGattCallback {
         TD1107("TD1107"),
         TNGSCALE("TNG SCALE"),
         AnDUC352("UC-352"),
+        TAIDOC_TD8255("TAIDOC TD8255"),
         TNGSPO2("TNG SPO2");
         
         private String text;

--- a/src/android/Peripheral.java
+++ b/src/android/Peripheral.java
@@ -441,6 +441,8 @@ public class Peripheral extends BluetoothGattCallback {
                 String text = device.getName();
                 if (text != null ) {
                     for (Peripheral.AUTO_CONNECT_OFF_DEVICES b : Peripheral.AUTO_CONNECT_OFF_DEVICES.values()) {
+//                        if(text.equals(b.text)) {
+//                            return true;
                         if(text.equals(b.text) || text.contains(b.text)) {
                             return true;
                         }

--- a/src/android/Peripheral.java
+++ b/src/android/Peripheral.java
@@ -19,6 +19,7 @@ import android.app.Activity;
 import android.bluetooth.*;
 import android.os.Build;
 import android.os.Handler;
+import android.os.Looper;
 import android.util.Base64;
 import timber.log.Timber;
 
@@ -497,14 +498,18 @@ public class Peripheral extends BluetoothGattCallback {
                     if (connected) {
                         Timber.i("Reconnection attempt for device " + getGattDeviceName(gatt) + " after gatt status code : " + status);
                         disconnect();
-                    } else {
-                        Timber.i("Gatt status code " + status + " for device " + getGattDeviceName(gatt) + " calling to connect");
-                        if (connectCallback != null && currentActivity != null) {
-                            Timber.i("Gatt status code " + status + " for device " + getGattDeviceName(gatt) + " Got callback, trying to Connect again");
-                            connect(connectCallback, currentActivity, false);
+                        } else {
+                                Timber.i("Gatt status code " + status + " for device " + getGattDeviceName(gatt) );
+                                final Handler handler = new Handler(Looper.getMainLooper());
+                                handler.postDelayed(() -> {
+                                    if (connectCallback != null && currentActivity != null) {
+                                        Timber.i("Got callback, Will Retry connection after 100ms");
+                                        connect(connectCallback, currentActivity, false); // it is recommended to retry after 100ms in case of gatt 133 connection issue
+                                    }
+                                }, 100);
+
                         }
                     }
-                }
             } else {
                 Timber.i("onConnectionStateChange DISCONNECTED for " + getGattDeviceName(gatt));
                 connected = false;

--- a/src/android/Peripheral.java
+++ b/src/android/Peripheral.java
@@ -479,9 +479,6 @@ public class Peripheral extends BluetoothGattCallback {
         // newState : Returns the new connection state. Can be one of BluetoothProfile.STATE_DISCONNECTED or BluetoothProfile#STATE_CONNECTED
         this.gatt = gatt;
         Timber.i(logConnectionStateChange(gatt, status, newState));
-        if(DEVICES_TO_ESCAPE_RETRY.notMatches(gatt.getDevice())){
-            Timber.i("Should not escape retry for " + gatt.getDevice());
-        }
         if (newState == BluetoothGatt.STATE_CONNECTED) {
             Timber.i("onConnectionStateChange CONNECTED " + getGattDeviceName(gatt));
             connected = true;
@@ -517,7 +514,7 @@ public class Peripheral extends BluetoothGattCallback {
             Timber.i("onConnectionStateChange else part! " + newState + " " + getGattDeviceName(gatt));
         }
     }
-    
+
     @Override
     public void onCharacteristicChanged(BluetoothGatt gatt, BluetoothGattCharacteristic characteristic) {
         super.onCharacteristicChanged(gatt, characteristic);

--- a/src/android/Peripheral.java
+++ b/src/android/Peripheral.java
@@ -415,8 +415,17 @@ public class Peripheral extends BluetoothGattCallback {
     public enum AUTO_CONNECT_OFF_DEVICES {
         WELCH_SC100("SC100"),
         TNG_SCALE("TNG SCALE"),
-        WELCH_BP100("BP100");
-
+        WELCH_BP100("BP100"),
+        NONIN_3230("Nonin3230"),
+        NIPRO("Nipro"),
+        TRUEAIR("TRUEAIR"),
+        AnDUA651("UA-651"),
+        FORAIR20("IR20"),
+        TD1107("TD1107"),
+        TNGSCALE("TNG SCALE"),
+        AnDUC352("UC-352"),
+        TNGSPO2("TNG SPO2");
+        
         private String text;
 
         AUTO_CONNECT_OFF_DEVICES(String text) {
@@ -432,7 +441,8 @@ public class Peripheral extends BluetoothGattCallback {
                 String text = device.getName();
                 if (text != null ) {
                     for (Peripheral.AUTO_CONNECT_OFF_DEVICES b : Peripheral.AUTO_CONNECT_OFF_DEVICES.values()) {
-                        if(text.equals(b.text)) {
+                        if(text.equals(b.text) || text.contains(b.text)) {
+                            Timber.d("Will retry for the connecting the device -> " + text);
                             return true;
                         }
                     }

--- a/src/android/Peripheral.java
+++ b/src/android/Peripheral.java
@@ -491,7 +491,6 @@ public class Peripheral extends BluetoothGattCallback {
         // status : Status of the connect or disconnect operation
         // newState : Returns the new connection state. Can be one of BluetoothProfile.STATE_DISCONNECTED or BluetoothProfile#STATE_CONNECTED
         this.gatt = gatt;
-        // Timber.i( "OnConnectionStateChange Status " + status + " to NewState " + newState);
         Timber.i(logConnectionStateChange(gatt, status, newState));
         if (newState == BluetoothGatt.STATE_CONNECTED) {
             Timber.i("onConnectionStateChange CONNECTED " + getGattDeviceName(gatt));

--- a/src/android/Peripheral.java
+++ b/src/android/Peripheral.java
@@ -441,8 +441,6 @@ public class Peripheral extends BluetoothGattCallback {
                 String text = device.getName();
                 if (text != null ) {
                     for (Peripheral.AUTO_CONNECT_OFF_DEVICES b : Peripheral.AUTO_CONNECT_OFF_DEVICES.values()) {
-//                        if(text.equals(b.text)) {
-//                            return true;
                         if(text.equals(b.text) || text.contains(b.text)) {
                             return true;
                         }


### PR DESCRIPTION
This MR address the following:
- Changes for allowing all the supported devices to retry to connect after gatt 133 error
- Added logs which inform about the connection state changes